### PR TITLE
 Получение общих фильмов 

### DIFF
--- a/0001-.patch
+++ b/0001-.patch
@@ -1,0 +1,153 @@
+From 8e3ab974e9c765683d8b922553b88fdde1eaa516 Mon Sep 17 00:00:00 2001
+From: Kazantsev <ka.yu.8@yandex.ru>
+Date: Sun, 4 Feb 2024 22:38:35 +0100
+Subject: [PATCH] =?UTF-8?q?=D0=98=D1=81=D0=BF=D1=80=D0=B0=D0=B2=D0=BB?=
+ =?UTF-8?q?=D0=B5=D0=BD=D1=8B=20=D0=BE=D1=88=D0=B8=D0=B1=D0=BA=D0=B8=20?=
+ =?UTF-8?q?=D0=B2=20=D1=80=D0=B0=D0=B1=D0=BE=D1=82=D0=B5=20=D0=BC=D0=B5?=
+ =?UTF-8?q?=D1=82=D0=BE=D0=B4=D0=B0,=20=D0=B4=D0=BE=D0=B1=D0=B0=D0=B2?=
+ =?UTF-8?q?=D0=BB=D0=B5=D0=BD=D1=8B=20=D0=BF=D1=80=D0=BE=D0=B2=D0=B5=D1=80?=
+ =?UTF-8?q?=D0=BA=D0=B8=20=D0=BD=D0=B0=20=D1=81=D1=83=D1=89=D0=B5=D1=81?=
+ =?UTF-8?q?=D1=82=D0=B2=D0=BE=D0=B2=D0=B0=D0=BD=D0=B8=D0=B5=20=D0=B4=D0=B0?=
+ =?UTF-8?q?=D0=BD=D0=BD=D1=8B=D1=85=20=D0=B2=20=D0=B1=D0=B0=D0=B7=D0=B5.?=
+ =?UTF-8?q?=20=D0=94=D0=BE=D0=B1=D0=B0=D0=B2=D0=BB=D0=B5=D0=BD=D0=BD=D0=B0?=
+ =?UTF-8?q?=20=D1=81=D0=BE=D1=80=D1=82=D0=B8=D1=80=D0=BE=D0=B2=D0=BA=D0=B0?=
+ =?UTF-8?q?=20=D0=BF=D0=BE=20=D0=BB=D0=B0=D0=B9=D0=BA=D0=B0=D0=BC.?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+---
+ .../filmorate/dao/impl/FilmDbStorage.java     | 56 +------------------
+ .../service/impl/FilmServiceImpl.java         | 19 ++++++-
+ 2 files changed, 20 insertions(+), 55 deletions(-)
+
+diff --git a/src/main/java/ru/yandex/practicum/filmorate/dao/impl/FilmDbStorage.java b/src/main/java/ru/yandex/practicum/filmorate/dao/impl/FilmDbStorage.java
+index ee35de0..501facb 100644
+--- a/src/main/java/ru/yandex/practicum/filmorate/dao/impl/FilmDbStorage.java
++++ b/src/main/java/ru/yandex/practicum/filmorate/dao/impl/FilmDbStorage.java
+@@ -201,42 +201,6 @@ public class FilmDbStorage implements FilmStorage {
+         return film;
+     }
+ 
+-    private Collection<Film> extractToFilmList(ResultSet rs) throws SQLException {
+-
+-        final Map<Long, Film> filmIdMap = new LinkedHashMap<>();
+-
+-        while (rs.next()) {
+-
+-            Long filmId = rs.getLong(1);
+-            Film film = filmIdMap.get(filmId);
+-            if (film == null) {
+-                film = Film.builder()
+-                        .id(filmId)
+-                        .name(rs.getString("title"))
+-                        .description(rs.getString("description"))
+-                        .releaseDate(rs.getDate("release_date").toLocalDate())
+-                        .duration(rs.getInt("duration"))
+-                        .mpa(new Mpa(rs.getInt("mpa_id"), rs.getString("rating_name")))
+-                        .build();
+-                film.setLikes(rs.getLong("likes"));
+-                filmIdMap.put(filmId, film);
+-            }
+-
+-            final int genre_id = rs.getInt("genre_id");
+-            if (genre_id == 0) {
+-                film.getGenres().addAll(Collections.emptyList());
+-                continue;
+-            }
+-
+-            final Genre genre = new Genre();
+-            genre.setId(genre_id);
+-            genre.setName(rs.getString("genre_name"));
+-            film.getGenres().add(genre);
+-        }
+-
+-        return filmIdMap.values();
+-    }
+-
+     @Override
+     public Collection<Film> findFilmsByIdsOrderByLikes(Set<Long> filmIds) {
+         if (filmIds.isEmpty()) {
+@@ -244,7 +208,6 @@ public class FilmDbStorage implements FilmStorage {
+         }
+ 
+         String placeholders = String.join(",", Collections.nCopies(filmIds.size(), "?"));
+-
+         String sql = "SELECT f.ID, f.TITLE, f.DESCRIPTION, f.RELEASE_DATE, f.DURATION, f.MPA_ID, " +
+                 "m.RATING_NAME, COUNT(fl.USER_ID) AS LIKES " +
+                 "FROM FILM f " +
+@@ -254,21 +217,8 @@ public class FilmDbStorage implements FilmStorage {
+                 "GROUP BY f.ID, m.RATING_NAME " +
+                 "ORDER BY LIKES DESC";
+ 
+-        Object[] idsArray = filmIds.toArray(new Object[0]);
+-
+-        return jdbcTemplate.query(sql, idsArray, new RowMapper<Film>() {
+-            @Override
+-            public Film mapRow(ResultSet rs, int rowNum) throws SQLException {
+-                Film film = new Film();
+-                film.setId(rs.getLong("ID"));
+-                film.setName(rs.getString("TITLE"));
+-                film.setDescription(rs.getString("DESCRIPTION"));
+-                film.setReleaseDate(rs.getDate("RELEASE_DATE").toLocalDate());
+-                film.setDuration(rs.getInt("DURATION"));
+-                film.setMpa(new Mpa(rs.getInt("MPA_ID"), rs.getString("RATING_NAME")));
+-                film.setLikes(rs.getLong("LIKES"));
+-                return film;
+-            }
+-        });
++        Object[] idsArray = filmIds.toArray();
++        return jdbcTemplate.query(sql, idsArray, this::mapToFilm);
+     }
++
+ }
+diff --git a/src/main/java/ru/yandex/practicum/filmorate/service/impl/FilmServiceImpl.java b/src/main/java/ru/yandex/practicum/filmorate/service/impl/FilmServiceImpl.java
+index 9c39283..014e0e0 100644
+--- a/src/main/java/ru/yandex/practicum/filmorate/service/impl/FilmServiceImpl.java
++++ b/src/main/java/ru/yandex/practicum/filmorate/service/impl/FilmServiceImpl.java
+@@ -9,6 +9,7 @@ import ru.yandex.practicum.filmorate.dao.FilmLikeStorage;
+ import ru.yandex.practicum.filmorate.dao.FilmStorage;
+ import ru.yandex.practicum.filmorate.dao.UserStorage;
+ import ru.yandex.practicum.filmorate.dto.FilmDto;
++import ru.yandex.practicum.filmorate.exception.NotFoundException;
+ import ru.yandex.practicum.filmorate.mapper.FilmMapper;
+ import ru.yandex.practicum.filmorate.model.Film;
+ import ru.yandex.practicum.filmorate.service.FilmService;
+@@ -159,8 +160,17 @@ public class FilmServiceImpl implements FilmService {
+      * @return список DTO фильмов, которые лайкнуты обоими пользователями. .
+      * Если общих лайкнутых фильмов нет, возвращается пустой список.
+      */
++    @Transactional
+     @Override
+     public Collection<FilmDto> getCommonFilms(long userId, long friendId) {
++        try {
++            userStorage.findById(userId);
++            userStorage.findById(friendId);
++        } catch (NotFoundException e) {
++            log.warn("Не найден пользователь с ID: {} или {}", userId, friendId);
++            return Collections.emptyList();
++        }
++
+         Set<Long> userLikedFilmIds = filmLikeStorage.findLikedFilmsByUser(userId);
+         Set<Long> friendLikedFilmIds = filmLikeStorage.findLikedFilmsByUser(friendId);
+ 
+@@ -171,9 +181,14 @@ public class FilmServiceImpl implements FilmService {
+         }
+ 
+         Collection<Film> commonFilms = filmStorage.findFilmsByIds(userLikedFilmIds);
+-        return commonFilms.stream().map(FilmMapper::toDto).collect(Collectors.toList());
+-    }
+ 
++        List<FilmDto> sortedCommonFilms = commonFilms.stream()
++                .sorted(Comparator.comparingLong(Film::getLikes).reversed())
++                .map(FilmMapper::toDto)
++                .collect(Collectors.toList());
++
++        return sortedCommonFilms;
++    }
+ 
+ 
+     /**
+-- 
+2.41.0.windows.3
+

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -70,5 +70,11 @@ public class FilmController {
     public Collection<FilmDto> getFilmsFromDirector(@PathVariable long directorId, @RequestParam String sortBy) {
         return filmService.getFilmsFromDirector(directorId, sortBy);
     }
+
+    @GetMapping("/common")
+    public Collection<FilmDto> getCommonFilms(@RequestParam long userId, @RequestParam long friendId) {
+        return filmService.getCommonFilms(userId, friendId);
+    }
+
 }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/dao/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/dao/FilmStorage.java
@@ -15,4 +15,6 @@ public interface FilmStorage extends Dao<Film> {
     Collection<Film> findFilmsFromDirectorOrderBy(long directorId, String sortBy);
 
     Collection<Film> findMostLikedFilms(int count, Integer genreId, Integer year);
+
+    Collection<Film> findFilmsByIdsOrderByLikes(Set<Long> filmIds);
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -25,4 +25,6 @@ public interface FilmService {
     Collection<FilmDto> searchFilms(FilmSearchDto search);
 
     Collection<FilmDto> getMostPopularFilms(int count, Integer genreId, Integer year);
+
+    Collection<FilmDto> getCommonFilms(long userId, long friendId);
 }


### PR DESCRIPTION
Добавлена функциональность получения общих фильмов с другом

- Реализован новый эндпоинт GET /films/common?userId={userId}&friendId={friendId} для вывода списка общих фильмов, отсортированных по популярности.
- Добавлена проверка на существование пользователей в базе данных перед поиском общих фильмов.
- Использованы существующие методы из FilmLikeStorage и UserStorage для оптимизации запросов к базе данных.
- Обновлена логика метода findFilmsByIdsOrderByLikes в FilmDbStorage для интеграции с новым функционалом и добавления режиссеров и жанров к фильмам.
- Маппинг результатов запроса адаптирован с использованием существующих мапперов для соответствия модели данных.
